### PR TITLE
Remove unnecessary library

### DIFF
--- a/proj2-dht/proj2-dht.ino
+++ b/proj2-dht/proj2-dht.ino
@@ -3,7 +3,6 @@
 // print sensor readings in this format:
 // <DHT temp °C> <DHT % humidity>
 
-#include <Adafruit_Sensor.h>
 #include <DHT.h>
 #include <DHT_U.h>
 


### PR DESCRIPTION
Removed an `#include` for a library that should not be necessary.

The new code should be tested to make sure it works.