### PR TITLE
Make titles in READMEs title case

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ To open a section, click on the folder of the appropriate name at the top of thi
 
 | Section | Contents |
 |-----|-----|
-| [Project 1: The Thermistor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj1-thermistor) | Analogue sensors, ADC, the Arduino IDE, uploading programs, the serial monitor, the three parts of sensor programs |
-| [Saving Sensor Data](https://github.com/duncanmacintyre/DIY-sensors/tree/master/saving-sensor-data) | Saving sensor data from the serial monitor to a file, opening in Excel |
-| [Project 2: The Digital Humidity-Temperature Sensor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj2-dht) | Digital sensors, installing libraries |
-| [Project 3: Using Multiple Sensors](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj3-multiple-sensors) | Adapting code, using multiple power buses |
+| [Project 1: The thermistor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj1-thermistor) | Analogue sensors, ADC, the Arduino IDE, uploading programs, the serial monitor, the three parts of sensor programs |
+| [Saving sensor data](https://github.com/duncanmacintyre/DIY-sensors/tree/master/saving-sensor-data) | Saving sensor data from the serial monitor to a file, opening in Excel |
+| [Project 2: The digital humidity-temperature sensor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj2-dht) | Digital sensors, installing libraries |
+| [Project 3: Using multiple sensors](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj3-multiple-sensors) | Adapting code, using multiple power buses |
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ To open a section, click on the folder of the appropriate name at the top of thi
 
 | Section | Contents |
 |-----|-----|
-| [Project 1: The thermistor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj1-thermistor) | Analogue sensors, ADC, the Arduino IDE, uploading programs, the serial monitor, the three parts of sensor programs |
-| [Saving sensor data](https://github.com/duncanmacintyre/DIY-sensors/tree/master/saving-sensor-data) | Saving sensor data from the serial monitor to a file, opening in Excel |
-| [Project 2: The digital humidity-temperature sensor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj2-dht) | Digital sensors, installing libraries |
-| [Project 3: Using multiple sensors](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj3-multiple-sensors) | Adapting code, using multiple power buses |
+| [Project 1: The Thermistor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj1-thermistor) | Analogue sensors, ADC, the Arduino IDE, uploading programs, the serial monitor, the three parts of sensor programs |
+| [Saving Sensor Data](https://github.com/duncanmacintyre/DIY-sensors/tree/master/saving-sensor-data) | Saving sensor data from the serial monitor to a file, opening in Excel |
+| [Project 2: The Digital Humidity-Temperature Sensor](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj2-dht) | Digital sensors, installing libraries |
+| [Project 3: Using Multiple Sensors](https://github.com/duncanmacintyre/DIY-sensors/tree/master/proj3-multiple-sensors) | Adapting code, using multiple power buses |
 
 &nbsp;
 

--- a/proj2-dht/README.md
+++ b/proj2-dht/README.md
@@ -1,4 +1,4 @@
-# Project 2: Digital sensors—The digital humidity-temperature sensor
+# Project 2: Digital Sensors—The Digital Humidity-temperature Sensor
 
 The digital humidity-temperature sensor (DHT) is an integrated circuit—that is, it contains several components packaged together into a nice, little, mini circuit for our convenience. Among other things, it contains
 

--- a/proj2-dht/README.md
+++ b/proj2-dht/README.md
@@ -1,4 +1,4 @@
-# Project 2: Digital Sensors—The Digital Humidity-temperature Sensor
+# Project 2: Digital Sensors—The Digital Humidity-Temperature Sensor
 
 The digital humidity-temperature sensor (DHT) is an integrated circuit—that is, it contains several components packaged together into a nice, little, mini circuit for our convenience. Among other things, it contains
 

--- a/proj3-multiple-sensors/README.md
+++ b/proj3-multiple-sensors/README.md
@@ -1,4 +1,4 @@
-# Project 3: Multiple sensors
+# Project 3: Multiple Sensors
 
 Here, we will combine our thermistor and DHT circuits together and get them both working at the same time.
 

--- a/saving-sensor-data/README.md
+++ b/saving-sensor-data/README.md
@@ -1,4 +1,4 @@
-# Saving sensor data
+# Saving Sensor Data
 
 *Table of contents*
   * [Monitoring the serial monitor](#monitoring-the-serial-monitor)


### PR DESCRIPTION
Changes all main titles in READMEs to be title case. Table of contents entries (in the main README) were left in regular case so as to be more readable.